### PR TITLE
YTI-448 Spring config update

### DIFF
--- a/config/application.yml
+++ b/config/application.yml
@@ -1,6 +1,9 @@
 ---
 spring:
   profiles: local
+  cloud:
+    config:
+      enabled: false
 
 management:
   # Set management port to 10000 + server.port (i.e. e.g. if server.port = 9601, management port = 19601).
@@ -63,6 +66,9 @@ environment:
 ---
 spring:
   profiles: docker
+  cloud:
+    config:
+      enabled: false
   jpa:
     #show-sql: true
     generate-ddl: false

--- a/config/application.yml
+++ b/config/application.yml
@@ -1,6 +1,8 @@
 ---
 spring:
-  profiles: local
+  config:
+    activate:
+      on-profile: local
   cloud:
     config:
       enabled: false
@@ -65,7 +67,9 @@ environment:
 
 ---
 spring:
-  profiles: docker
+  config:
+    activate:
+      on-profile: docker
   cloud:
     config:
       enabled: false

--- a/config/yti-codelist-content-intake-service.yml
+++ b/config/yti-codelist-content-intake-service.yml
@@ -1,6 +1,8 @@
 ---
 spring:
-  profiles: local
+  config:
+    activate:
+      on-profile: local
   application:
     name: yti-codelist-content-intake-service
   jpa:
@@ -89,7 +91,9 @@ fake:
 
 ---
 spring:
-  profiles: docker
+  config:
+    activate:
+      on-profile: docker
   application:
     name: yti-codelist-content-intake-service
 

--- a/config/yti-codelist-public-api-service.yml
+++ b/config/yti-codelist-public-api-service.yml
@@ -1,6 +1,8 @@
 ---
 spring:
-  profiles: local
+  config:
+    activate:
+      on-profile: local
   application:
     name: yti-codelist-public-api-service
 
@@ -43,7 +45,9 @@ yti_codelist_public_api_service_elastic_cluster: ${environment.codelist-elastic.
 
 ---
 spring:
-  profiles: docker
+  config:
+    activate:
+      on-profile: docker
   application:
     name: yti-codelist-public-api-service
 

--- a/config/yti-comments-api.yml
+++ b/config/yti-comments-api.yml
@@ -1,6 +1,8 @@
 ---
 spring:
-  profiles: local
+  config:
+    activate:
+      on-profile: local
   application:
     name: yti-comments-api
   jpa:
@@ -83,7 +85,9 @@ hikari:
 
 ---
 spring:
-  profiles: docker
+  config:
+    activate:
+      on-profile: docker
   application:
     name: yti-comments-api
   jpa:

--- a/config/yti-datamodel-api.yml
+++ b/config/yti-datamodel-api.yml
@@ -1,6 +1,8 @@
 ---
 spring:
-  profiles: local
+  config:
+    activate:
+      on-profile: local
 
 server:
   port: 9004
@@ -55,8 +57,10 @@ impersonate:
 
 ---
 spring:
-  profiles: docker
-
+  config:
+    activate:
+      on-profile: local
+      
 server:
   port: 9004
 

--- a/config/yti-groupmanagement.yml
+++ b/config/yti-groupmanagement.yml
@@ -17,6 +17,8 @@ spring:
     url: jdbc:postgresql://${environment.postgres.host}:${environment.postgres.port}/${service.database-name}
     username: postgres
     password:
+  flyway:
+    table: schema_version
 
 service:
   database-name: groupmanagement
@@ -44,6 +46,9 @@ environment:
 send:
   admin:
     emails: false
+    
+admin:
+  email: "y-alusta.tuotetiimi@dvv.fi"
 
 application:
   codeListUrl: ${environment.codelist.public-url}
@@ -82,6 +87,8 @@ spring:
     url: jdbc:postgresql://${environment.postgres.host}:${environment.postgres.port}/${service.database-name}
     username: postgres
     password:
+  flyway:
+    table: schema_version
 
 service:
   database-name: groupmanagement
@@ -109,6 +116,9 @@ environment:
 send:
   admin:
     emails: false
+
+admin:
+  email: "y-alusta.tuotetiimi@dvv.fi"
 
 application:
   codeListUrl: ${environment.codelist.public-url}

--- a/config/yti-messaging-api.yml
+++ b/config/yti-messaging-api.yml
@@ -1,6 +1,8 @@
 ---
 spring:
-  profiles: local
+  config:
+    activate:
+      on-profile: local
   application:
     name: yti-messaging-api
   mail:
@@ -82,7 +84,9 @@ admin:
 
 ---
 spring:
-  profiles: docker
+  config:
+    activate:
+      on-profile: docker
   application:
     name: yti-messaging-api
   mail:

--- a/config/yti-terminology-api.yml
+++ b/config/yti-terminology-api.yml
@@ -1,6 +1,8 @@
 ---
 spring:
-  profiles: local
+  config:
+    activate:
+      on-profile: local
   http:
     multipart:
       enabled: true
@@ -88,7 +90,9 @@ fake:
 
 ---
 spring:
-  profiles: docker
+  config:
+    activate:
+      on-profile: docker
   http:
     multipart:
       enabled: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,7 +109,6 @@ services:
      - "SPRING_CONFIG_LOCATION=/config/application.yml,/config/yti-groupmanagement.yml"
     depends_on:
      - yti-postgres
-    command: ["./wait-for-it.sh", "localhost", "5432"]
     links:
      - yti-postgres
     networks:


### PR DESCRIPTION
Config changes required by new Spring boot version. Only applied to applications with java 11 / Spring boot 2.5.2 update (at the moment terminology-api, codelist-public-api and codelist-content-intake-service)